### PR TITLE
Fix assist by including line no information, and ignoring syntax errors at the current line number

### DIFF
--- a/supplement/assistant.py
+++ b/supplement/assistant.py
@@ -284,7 +284,7 @@ def assist(project, source, position, filename):
     ctx_type, lineno, ctx, match, fctx = get_context(source, position)
     if ctx_type == 'expr':
         source = sanitize_encoding(source)
-        ast_nodes, fixed_source = fix(source)
+        ast_nodes, fixed_source = fix(source, lineno=lineno)
 
         scope = get_scope_at(project, fixed_source, lineno, filename, ast_nodes)
         project.calldb.collect_calls(scope.get_toplevel(), True)
@@ -325,7 +325,7 @@ def get_location(project, source, position, filename):
 
     if ctx_type == 'expr':
         source = sanitize_encoding(source)
-        ast_nodes, fixed_source = fix(source)
+        ast_nodes, fixed_source = fix(source, lineno=lineno)
         scope = get_scope_at(project, fixed_source, lineno, filename, ast_nodes)
         if not ctx:
             obj = scope.find_name(match, lineno)
@@ -360,7 +360,7 @@ def get_docstring(project, source, position, filename):
     ctx_type, lineno, ctx, match, fctx = get_context(source, position)
     if ctx_type == 'expr' and fctx:
         source = sanitize_encoding(source)
-        ast_nodes, fixed_source = fix(source)
+        ast_nodes, fixed_source = fix(source, lineno=lineno)
         scope = get_scope_at(project, fixed_source, lineno, filename, ast_nodes)
         obj = infer(fctx, scope, lineno)
 

--- a/supplement/fixer.py
+++ b/supplement/fixer.py
@@ -142,13 +142,13 @@ def try_to_fix(error, code, lineno):
 def fix(code, lineno=0, tries=10):
     try:
         return ast.parse(code), code
-    except IndentationError, e:
+    except (SyntaxError, IndentationError), e:
         tries -= 1
         if tries <= 0:
             raise
 
         code, fixed_location = try_to_fix(e, code, lineno)
         if fixed_location and e.lineno == lineno:
-            return fix(code, lineno, tries)
+            return fix(code, lineno=lineno, tries=tries)
         else:
             raise


### PR DESCRIPTION
This passes the canopy tests.
